### PR TITLE
Turn import/no-extraneous-dependencies on with devDependencies included

### DIFF
--- a/index.json
+++ b/index.json
@@ -34,7 +34,7 @@
     "flowtype/valid-syntax": "error",
     "generator-star-spacing": "off",
     "import/no-unresolved": "error",
-    "import/no-extraneous-dependencies": "off",
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
     "jsx-a11y/anchor-is-valid": "off",
     "no-console": "off",
     "no-use-before-define": "off",


### PR DESCRIPTION
This rule must have been turned off because of `devDependencies` being bundled in via `webpack` but still giving errors from `eslint-plugin-import`. With the `devDependencies` option turned on, errors won't occur when importing packages that are either under `dependencies` or `devDependencies`.